### PR TITLE
Add touch-friendly mobile controls

### DIFF
--- a/src/scenes/snakeScene.ts
+++ b/src/scenes/snakeScene.ts
@@ -9,6 +9,7 @@ import { QuestPopup } from "../ui/questPopup.js";
 import { SnakeRenderer } from "../ui/snakeRenderer.js";
 import { JuiceManager } from "../ui/juice.js";
 import { BossHud } from "../ui/bossHud.js";
+import { createMobileControls, type MobileControls } from "../ui/mobileControls.js";
 import type { Quest } from "../../quests.js";
 import type { AppleSnapshot } from "../apples/types.js";
 import type { Vector2Like } from "../core/math.js";
@@ -27,6 +28,7 @@ export default class SnakeScene extends Phaser.Scene {
   private juice!: JuiceManager;
   private skillTree!: SkillTreeManager;
   private bossHud!: BossHud;
+  private mobileControls: MobileControls | null = null;
   private activeBossId: string | null = null;
   private lastBossHealth: Map<string, number> = new Map();
   private powerupMusicActive = false;
@@ -71,6 +73,18 @@ export default class SnakeScene extends Phaser.Scene {
 
     this.setupInputHandlers();
 
+    this.mobileControls = createMobileControls({
+      onDirection: (x, y) => {
+        this.setDir(x, y);
+      },
+      onTogglePause: () => {
+        this.togglePauseMenu();
+      },
+    });
+
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, this.handleShutdown, this);
+    this.events.once(Phaser.Scenes.Events.DESTROY, this.handleShutdown, this);
+
     this.questHud = new QuestHud(this, {
       position: { x: this.grid.cols * this.grid.cell - 10, y: 8 },
     });
@@ -96,14 +110,7 @@ export default class SnakeScene extends Phaser.Scene {
     this.input.keyboard?.on("keydown", (event: KeyboardEvent) => {
       const key = event.key.toLowerCase();
       if (key === " ") {
-        if (this.offeredQuest) return;
-        this.paused = !this.paused;
-        this.skillTree.toggleOverlay(this.paused ? true : false);
-        if (this.paused) {
-          this.juice.skillTreeOpened();
-        } else {
-          this.juice.skillTreeClosed();
-        }
+        this.togglePauseMenu();
         return;
       }
 
@@ -332,6 +339,27 @@ export default class SnakeScene extends Phaser.Scene {
 
   setDir(x: number, y: number) {
     this.game.setDirection(x, y);
+  }
+
+  private togglePauseMenu(force?: boolean): void {
+    if (this.offeredQuest) return;
+    const nextState = typeof force === "boolean" ? force : !this.paused;
+    if (nextState === this.paused) {
+      return;
+    }
+
+    this.paused = nextState;
+    this.skillTree.toggleOverlay(this.paused ? true : false);
+    if (this.paused) {
+      this.juice.skillTreeOpened();
+    } else {
+      this.juice.skillTreeClosed();
+    }
+  }
+
+  private handleShutdown(): void {
+    this.mobileControls?.destroy();
+    this.mobileControls = null;
   }
 
   addScore(amount: number) {

--- a/src/style.css
+++ b/src/style.css
@@ -3,3 +3,70 @@ body {
   padding: 0;
   background-color: #000;
 }
+
+.mobile-controls {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  font-family: "monospace", monospace;
+}
+
+.mobile-controls__dpad {
+  position: absolute;
+  left: 16px;
+  bottom: 16px;
+  display: grid;
+  grid-template-columns: repeat(3, 64px);
+  grid-template-rows: repeat(3, 64px);
+  gap: 10px;
+  pointer-events: auto;
+}
+
+.mobile-controls__actions {
+  position: absolute;
+  right: 20px;
+  bottom: 36px;
+  display: flex;
+  gap: 12px;
+  pointer-events: auto;
+}
+
+.mobile-controls__button {
+  width: 64px;
+  height: 64px;
+  border-radius: 18px;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  background: rgba(9, 12, 18, 0.78);
+  color: #f0f6ff;
+  font-size: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+  touch-action: manipulation;
+  user-select: none;
+}
+
+.mobile-controls__button:active {
+  transform: scale(0.94);
+  background: rgba(15, 22, 32, 0.95);
+}
+
+.mobile-controls__button--pause {
+  width: 88px;
+  height: 88px;
+  font-size: 18px;
+  letter-spacing: 0.05em;
+}
+
+.mobile-controls__spacer {
+  width: 64px;
+  height: 64px;
+  pointer-events: none;
+}
+
+@media (pointer: fine) {
+  .mobile-controls {
+    display: none;
+  }
+}

--- a/src/ui/mobileControls.ts
+++ b/src/ui/mobileControls.ts
@@ -1,0 +1,127 @@
+const isCoarsePointer = () => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const coarseMediaQuery = window.matchMedia?.("(pointer: coarse)");
+  if (coarseMediaQuery?.matches) {
+    return true;
+  }
+
+  if (typeof navigator !== "undefined" && navigator.maxTouchPoints > 0) {
+    return true;
+  }
+
+  return false;
+};
+
+export interface MobileControls {
+  destroy(): void;
+}
+
+interface MobileControlsOptions {
+  onDirection: (x: number, y: number) => void;
+  onTogglePause: () => void;
+}
+
+export function createMobileControls(options: MobileControlsOptions): MobileControls | null {
+  if (!isCoarsePointer()) {
+    return null;
+  }
+
+  const container = document.createElement("div");
+  container.className = "mobile-controls";
+
+  const dpad = document.createElement("div");
+  dpad.className = "mobile-controls__dpad";
+
+  const actions = document.createElement("div");
+  actions.className = "mobile-controls__actions";
+
+  const cleanupCallbacks: Array<() => void> = [];
+
+  const addDirectionalButton = (label: string, x: number, y: number, className: string) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = `mobile-controls__button mobile-controls__button--${className}`;
+    button.setAttribute("aria-label", label);
+    button.textContent = label;
+
+    const handler = (event: PointerEvent) => {
+      event.preventDefault();
+      options.onDirection(x, y);
+    };
+
+    const cancelContextMenu = (event: Event) => event.preventDefault();
+
+    button.addEventListener("pointerdown", handler);
+    button.addEventListener("contextmenu", cancelContextMenu);
+
+    cleanupCallbacks.push(() => {
+      button.removeEventListener("pointerdown", handler);
+      button.removeEventListener("contextmenu", cancelContextMenu);
+    });
+
+    dpad.appendChild(button);
+  };
+
+  // Layout: create 9 slots for a simple D-pad layout
+  const layout: Array<Array<{ label?: string; x?: number; y?: number; className?: string }>> = [
+    [{}, { label: "▲", x: 0, y: -1, className: "up" }, {}],
+    [
+      { label: "◀", x: -1, y: 0, className: "left" },
+      {},
+      { label: "▶", x: 1, y: 0, className: "right" },
+    ],
+    [{}, { label: "▼", x: 0, y: 1, className: "down" }, {}],
+  ];
+
+  for (const row of layout) {
+    for (const cell of row) {
+      if (cell.label && typeof cell.x === "number" && typeof cell.y === "number" && cell.className) {
+        addDirectionalButton(cell.label, cell.x, cell.y, cell.className);
+      } else {
+        const spacer = document.createElement("div");
+        spacer.className = "mobile-controls__spacer";
+        dpad.appendChild(spacer);
+      }
+    }
+  }
+
+  const pauseButton = document.createElement("button");
+  pauseButton.type = "button";
+  pauseButton.className = "mobile-controls__button mobile-controls__button--pause";
+  pauseButton.textContent = "Menu";
+  pauseButton.setAttribute("aria-label", "Toggle menu");
+
+  const pauseHandler = (event: PointerEvent) => {
+    event.preventDefault();
+    options.onTogglePause();
+  };
+
+  const cancelPauseContextMenu = (event: Event) => event.preventDefault();
+
+  pauseButton.addEventListener("pointerdown", pauseHandler);
+  pauseButton.addEventListener("contextmenu", cancelPauseContextMenu);
+
+  cleanupCallbacks.push(() => {
+    pauseButton.removeEventListener("pointerdown", pauseHandler);
+    pauseButton.removeEventListener("contextmenu", cancelPauseContextMenu);
+  });
+
+  actions.appendChild(pauseButton);
+
+  container.appendChild(dpad);
+  container.appendChild(actions);
+
+  document.body.appendChild(container);
+
+  return {
+    destroy: () => {
+      for (const cleanup of cleanupCallbacks) {
+        cleanup();
+      }
+      container.remove();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add a DOM-based mobile controls overlay that appears on coarse pointer devices
- hook the mobile controls into the snake scene for movement and pause toggling
- style the controls for touch interaction while hiding them on desktop

## Testing
- npm run dev -- --host 0.0.0.0 --clearScreen false
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68f5a09d03b0832585781a760cff452a