### PR TITLE
Add seeded quest targets

### DIFF
--- a/src/quests/__tests__/seededQuestTargets.test.ts
+++ b/src/quests/__tests__/seededQuestTargets.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseSeededQuestRoomId,
+  resolveCultTempleTarget,
+  resolveLetterDeliveryTarget,
+} from '../seededQuestTargets.js';
+
+describe('seeded quest targets', () => {
+  it('resolves letter targets deterministically for the same seed and origin room', () => {
+    const first = resolveLetterDeliveryTarget('run:test-seed', '4,-2,0', 'letter-for-the-unspawned');
+    const second = resolveLetterDeliveryTarget('run:test-seed', '4,-2,0', 'letter-for-the-unspawned');
+
+    expect(second).toEqual(first);
+  });
+
+  it('places letter targets exactly thirty rooms away on the same depth by default', () => {
+    const origin = parseSeededQuestRoomId('4,-2,3');
+    const target = resolveLetterDeliveryTarget('run:test-seed', '4,-2,3', 'letter-for-the-unspawned');
+
+    expect(target.coord.z).toBe(origin.z);
+    expect(Math.abs(target.coord.x - origin.x) + Math.abs(target.coord.y - origin.y)).toBe(30);
+    expect(target.distanceFromOrigin).toBe(30);
+    expect(target.npcName).toBeTruthy();
+  });
+
+  it('places the buried temple at the requested depth without generating any rooms', () => {
+    const target = resolveCultTempleTarget('run:test-seed', 'buried-temple-artifact', -20);
+
+    expect(target.coord.z).toBe(-20);
+    expect(target.roomId.endsWith(',-20')).toBe(true);
+    expect(target.artifactName).toBeTruthy();
+  });
+});

--- a/src/quests/definitions/seededWorldQuests.ts
+++ b/src/quests/definitions/seededWorldQuests.ts
@@ -1,0 +1,100 @@
+import { Quest, type QuestRuntime } from '../quest.js';
+import {
+  getRuntimeRoomId,
+  getRuntimeWorldSeed,
+  resolveCultTempleTarget,
+  resolveLetterDeliveryTarget,
+  type SeededQuestTarget,
+} from '../seededQuestTargets.js';
+
+const TEMPLE_TARGET_FLAG = 'quest.seeded.temple.target';
+const TEMPLE_FOUND_FLAG = 'quest.seeded.temple.found';
+const LETTER_TARGET_FLAG = 'quest.seeded.letter.target';
+const LETTER_DELIVERED_FLAG = 'quest.seeded.letter.delivered';
+
+class BuriedTempleQuest extends Quest {
+  constructor() {
+    super(
+      'buried-temple-artifact',
+      'The Temple Below Twenty',
+      'Descend to depth -20 and reach the temple room selected by this run seed.',
+    );
+  }
+
+  override onAccept(runtime: QuestRuntime): void {
+    super.onAccept(runtime);
+    const target = resolveCultTempleTarget(getRuntimeWorldSeed(runtime), this.id);
+    runtime.setFlag(TEMPLE_TARGET_FLAG, target);
+    runtime.setFlag('quest.seeded.activeTargetRoomId', target.roomId);
+    runtime.setFlag('quest.seeded.activeTargetDescription', target.description);
+  }
+
+  isCompleted(runtime: QuestRuntime): boolean {
+    const target = getOrCreateTempleTarget(runtime);
+    return Boolean(runtime.getFlag<boolean>(TEMPLE_FOUND_FLAG)) || getRuntimeRoomId(runtime) === target.roomId;
+  }
+
+  override onReward(runtime: QuestRuntime): void {
+    const target = getOrCreateTempleTarget(runtime);
+    runtime.setFlag(TEMPLE_FOUND_FLAG, true);
+    runtime.setFlag('quest.seeded.temple.artifactName', target.artifactName ?? 'temple artifact');
+    runtime.addScore(75);
+  }
+}
+
+class LetterDeliveryQuest extends Quest {
+  constructor() {
+    super(
+      'letter-for-the-unspawned',
+      'Letter for the Unspawned',
+      'Deliver a letter to a named stranger roughly 30 zones away. The recipient is selected by this run seed.',
+    );
+  }
+
+  override onAccept(runtime: QuestRuntime): void {
+    super.onAccept(runtime);
+    const originRoomId = getRuntimeRoomId(runtime);
+    const target = resolveLetterDeliveryTarget(getRuntimeWorldSeed(runtime), originRoomId, this.id);
+    runtime.setFlag(LETTER_TARGET_FLAG, target);
+    runtime.setFlag('quest.seeded.activeTargetRoomId', target.roomId);
+    runtime.setFlag('quest.seeded.activeTargetDescription', target.description);
+  }
+
+  isCompleted(runtime: QuestRuntime): boolean {
+    const target = getOrCreateLetterTarget(runtime);
+    return Boolean(runtime.getFlag<boolean>(LETTER_DELIVERED_FLAG)) || getRuntimeRoomId(runtime) === target.roomId;
+  }
+
+  override onReward(runtime: QuestRuntime): void {
+    const target = getOrCreateLetterTarget(runtime);
+    runtime.setFlag(LETTER_DELIVERED_FLAG, true);
+    runtime.setFlag('quest.seeded.letter.recipientName', target.npcName ?? target.displayName);
+    runtime.addScore(35);
+  }
+}
+
+function getOrCreateTempleTarget(runtime: QuestRuntime): SeededQuestTarget {
+  const existing = runtime.getFlag<SeededQuestTarget>(TEMPLE_TARGET_FLAG);
+  if (existing) {
+    return existing;
+  }
+  const target = resolveCultTempleTarget(getRuntimeWorldSeed(runtime), 'buried-temple-artifact');
+  runtime.setFlag(TEMPLE_TARGET_FLAG, target);
+  return target;
+}
+
+function getOrCreateLetterTarget(runtime: QuestRuntime): SeededQuestTarget {
+  const existing = runtime.getFlag<SeededQuestTarget>(LETTER_TARGET_FLAG);
+  if (existing) {
+    return existing;
+  }
+  const target = resolveLetterDeliveryTarget(
+    getRuntimeWorldSeed(runtime),
+    getRuntimeRoomId(runtime),
+    'letter-for-the-unspawned',
+  );
+  runtime.setFlag(LETTER_TARGET_FLAG, target);
+  return target;
+}
+
+export default [new BuriedTempleQuest(), new LetterDeliveryQuest()];

--- a/src/quests/seededQuestTargets.ts
+++ b/src/quests/seededQuestTargets.ts
@@ -1,0 +1,170 @@
+import { createRng } from '../core/rng.js';
+
+export interface SeededQuestRoomCoord {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export type SeededQuestTargetKind = 'cult-temple' | 'letter-recipient';
+
+export interface SeededQuestTarget {
+  questId: string;
+  kind: SeededQuestTargetKind;
+  roomId: string;
+  coord: SeededQuestRoomCoord;
+  displayName: string;
+  description: string;
+  distanceFromOrigin: number;
+  npcName?: string;
+  artifactName?: string;
+}
+
+const LETTER_FIRST_NAMES = [
+  'Mara',
+  'Corin',
+  'Isolde',
+  'Pavel',
+  'Nia',
+  'Oren',
+  'Selka',
+  'Tamsin',
+  'Voss',
+  'Elian',
+] as const;
+
+const LETTER_LAST_NAMES = [
+  'Wick',
+  'Glass',
+  'Holloway',
+  'Underbranch',
+  'Morrow',
+  'Farfield',
+  'Kettle',
+  'Northgate',
+  'Ash',
+  'Bellweather',
+] as const;
+
+const CULT_ARTIFACT_NAMES = [
+  'The Knotted Idol',
+  'The Serpent Reliquary',
+  'The Bell Without a Tongue',
+  'The Black Orchard Seed',
+  'The Choir-Stone',
+  'The Unblinking Coin',
+] as const;
+
+export function parseSeededQuestRoomId(roomId: string): SeededQuestRoomCoord {
+  const [rawX, rawY, rawZ] = roomId.split(',');
+  return {
+    x: Number(rawX ?? 0) || 0,
+    y: Number(rawY ?? 0) || 0,
+    z: Number(rawZ ?? 0) || 0,
+  };
+}
+
+export function formatSeededQuestRoomId(coord: SeededQuestRoomCoord): string {
+  return `${coord.x},${coord.y},${coord.z}`;
+}
+
+export function getRuntimeWorldSeed(runtime: {
+  worldSeed?: string;
+  getFlag?: <T = unknown>(key: string) => T | undefined;
+}): string {
+  const flagSeed = runtime.getFlag?.<string>('world.seed');
+  if (typeof runtime.worldSeed === 'string' && runtime.worldSeed.length > 0) {
+    return runtime.worldSeed;
+  }
+  if (typeof flagSeed === 'string' && flagSeed.length > 0) {
+    return flagSeed;
+  }
+  return 'default-world';
+}
+
+export function getRuntimeRoomId(runtime: {
+  getCurrentRoomId?: () => string | undefined;
+  getCurrentRoom?: () => { id?: string } | undefined;
+  getFlag?: <T = unknown>(key: string) => T | undefined;
+}): string {
+  const explicit = runtime.getCurrentRoomId?.();
+  if (explicit) {
+    return explicit;
+  }
+  const room = runtime.getCurrentRoom?.();
+  if (room?.id) {
+    return room.id;
+  }
+  const flagged = runtime.getFlag?.<string>('currentRoomId');
+  return flagged || '0,0,0';
+}
+
+export function resolveLetterDeliveryTarget(
+  worldSeed: string,
+  originRoomId: string,
+  questId = 'letter-for-the-unspawned',
+  distance = 30,
+): SeededQuestTarget {
+  const origin = parseSeededQuestRoomId(originRoomId);
+  const rng = createRng(`${worldSeed}:seeded-quest:${questId}:letter:${originRoomId}:${distance}`);
+  const offset = pickManhattanRingOffset(distance, rng);
+  const coord = {
+    x: origin.x + offset.x,
+    y: origin.y + offset.y,
+    z: origin.z,
+  };
+  const npcName = `${pick(LETTER_FIRST_NAMES, rng)} ${pick(LETTER_LAST_NAMES, rng)}`;
+  const roomId = formatSeededQuestRoomId(coord);
+  return {
+    questId,
+    kind: 'letter-recipient',
+    roomId,
+    coord,
+    displayName: npcName,
+    npcName,
+    distanceFromOrigin: manhattanDistance(origin, coord),
+    description: `Deliver the letter to ${npcName}, ${distance} zones away at ${roomId}.`,
+  };
+}
+
+export function resolveCultTempleTarget(
+  worldSeed: string,
+  questId = 'cult-temple-artifact',
+  depth = -20,
+): SeededQuestTarget {
+  const rng = createRng(`${worldSeed}:seeded-quest:${questId}:cult-temple:${depth}`);
+  const coord = {
+    x: Math.floor(rng() * 41) - 20,
+    y: Math.floor(rng() * 41) - 20,
+    z: depth,
+  };
+  const artifactName = pick(CULT_ARTIFACT_NAMES, rng);
+  const roomId = formatSeededQuestRoomId(coord);
+  return {
+    questId,
+    kind: 'cult-temple',
+    roomId,
+    coord,
+    displayName: 'Buried Cult Temple',
+    artifactName,
+    distanceFromOrigin: Math.abs(coord.x) + Math.abs(coord.y) + Math.abs(coord.z),
+    description: `Find the cult temple at depth ${depth} in room ${roomId} and recover ${artifactName}.`,
+  };
+}
+
+function pick<T>(values: readonly T[], rng: () => number): T {
+  return values[Math.floor(rng() * values.length)] ?? values[0];
+}
+
+function pickManhattanRingOffset(distance: number, rng: () => number): { x: number; y: number } {
+  const safeDistance = Math.max(1, Math.floor(distance));
+  const absX = Math.floor(rng() * (safeDistance + 1));
+  const absY = safeDistance - absX;
+  const x = absX === 0 ? 0 : absX * (rng() < 0.5 ? -1 : 1);
+  const y = absY === 0 ? 0 : absY * (rng() < 0.5 ? -1 : 1);
+  return { x, y };
+}
+
+function manhattanDistance(a: SeededQuestRoomCoord, b: SeededQuestRoomCoord): number {
+  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y) + Math.abs(a.z - b.z);
+}


### PR DESCRIPTION
## Summary
- Add a deterministic quest target resolver based on the run/world seed.
- Add two quest definitions: one deep-room objective at depth -20 and one delivery objective exactly 30 zones from the acceptance room.
- Add Vitest coverage for deterministic resolution, delivery distance, and depth targeting.

## Notes
- This first pass makes the targets and quests functional through existing quest runtime flags.
- It does not yet add custom room stamping or target NPC rendering.
- Tests were not run from this environment; please validate with `npm test` or `npx vitest run src/quests/__tests__/seededQuestTargets.test.ts`.